### PR TITLE
refactor(byoapi): rename title to name (2 of 3)

### DIFF
--- a/db/migrations/20161005162905_backfill_movies_name.js
+++ b/db/migrations/20161005162905_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -5,7 +5,6 @@ const Movie = require('../../../models/movie');
 exports.create = (payload) => {
   const attributes = {
     name: payload.title,
-    title: payload.title,
     release_year: payload.release_year
   };
 


### PR DESCRIPTION
_What_:
Rename title to name on the movies table.

_Why_:
This is part of the zero downtime tutorial for the BYOAPI section of Miyagi.

_Details_:
- See #6 for context - changes in this PR include the introduction of `20161005162905_backfill_movies_name.js` and not saving the `title` attribute anymore.
- Includes migration that updates the `name` column based on the value of `title`
