### PR TITLE
refactor(byoapi): rename title to name (3 of 3)

### DIFF
--- a/db/migrations/20161005171615_drop_title_from_movies.js
+++ b/db/migrations/20161005171615_drop_title_from_movies.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+  });
+};
+

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize () {
     return {
       id: this.get('id'),
-      title: this.get('name') || this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -17,16 +17,6 @@ describe('movie model', () => {
       ]);
     });
 
-    it('returns the name or title column as the title', () => {
-      const title = 'The Room';
-
-      const movieWithTitle = Movie.forge({ title }).serialize();
-      const movieWithName = Movie.forge({ name: title }).serialize();
-
-      expect(movieWithTitle.title).to.eql(title);
-      expect(movieWithName.title).to.eql(title);
-    });
-
   });
 
 });


### PR DESCRIPTION
**What:**
Rename title to name on the movies table.

**Why:**
This is part of the zero downtime tutorial for the BYOAPI section of Miyagi.

**Details:**
- See #6 and #7 for context
- Includes migration that drops the `title` column from the `movies` table
- Serialized Movie only accesses `name` column
