### PR TITLE
feat(byoapi): Create locations model and table

### DIFF
--- a/db/migrations/20161007150914_create_locations.js
+++ b/db/migrations/20161007150914_create_locations.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.schema.createTable('locations', (table) => {
+    table.increments('id').primary();
+    table.text('city').notNullable();
+    table.text('state').notNullable();
+  });
+};
+
+exports.down = function (knex, Promise) {
+  knex.schema.dropTable('locations');
+};

--- a/db/seeds/data/locations.json
+++ b/db/seeds/data/locations.json
@@ -1,0 +1,4 @@
+[{
+  "city": "San Francisco",
+  "state": "CA"
+}]

--- a/db/seeds/data/movies.json
+++ b/db/seeds/data/movies.json
@@ -1,1096 +1,1096 @@
 [{
-  "title": "180",
+  "name": "180",
   "release_year": 2011
 },
 {
-  "title": "24 Hours on Craigslist",
+  "name": "24 Hours on Craigslist",
   "release_year": 2005
 },
 {
-  "title": "40 Days and 40 Nights",
+  "name": "40 Days and 40 Nights",
   "release_year": 2002
 },
 {
-  "title": "48 Hours",
+  "name": "48 Hours",
   "release_year": 1982
 },
 {
-  "title": "50 First Dates",
+  "name": "50 First Dates",
   "release_year": 2004
 },
 {
-  "title": "A Jitney Elopement",
+  "name": "A Jitney Elopement",
   "release_year": 1915
 },
 {
-  "title": "A Night Full of Rain",
+  "name": "A Night Full of Rain",
   "release_year": 1978
 },
 {
-  "title": "A Smile Like Yours",
+  "name": "A Smile Like Yours",
   "release_year": 1997
 },
 {
-  "title": "A View to a Kill",
+  "name": "A View to a Kill",
   "release_year": 1985
 },
 {
-  "title": "About a Boy",
+  "name": "About a Boy",
   "release_year": 2014
 },
 {
-  "title": "After the Thin Man",
+  "name": "After the Thin Man",
   "release_year": 1936
 },
 {
-  "title": "Age of Adaline",
+  "name": "Age of Adaline",
   "release_year": 2015
 },
 {
-  "title": "Alcatraz",
+  "name": "Alcatraz",
   "release_year": 2012
 },
 {
-  "title": "Alexander's Ragtime Band",
+  "name": "Alexander's Ragtime Band",
   "release_year": 1938
 },
 {
-  "title": "All About Eve",
+  "name": "All About Eve",
   "release_year": 1950
 },
 {
-  "title": "American Graffiti",
+  "name": "American Graffiti",
   "release_year": 1973
 },
 {
-  "title": "American Yearbook",
+  "name": "American Yearbook",
   "release_year": 2004
 },
 {
-  "title": "Americana",
+  "name": "Americana",
   "release_year": 2015
 },
 {
-  "title": "Another 48 Hours",
+  "name": "Another 48 Hours",
   "release_year": 1990
 },
 {
-  "title": "Ant-Man",
+  "name": "Ant-Man",
   "release_year": 2015
 },
 {
-  "title": "Around the Fire",
+  "name": "Around the Fire",
   "release_year": 1998
 },
 {
-  "title": "Attack of the Killer Tomatoes",
+  "name": "Attack of the Killer Tomatoes",
   "release_year": 1978
 },
 {
-  "title": "Babies",
+  "name": "Babies",
   "release_year": 2010
 },
 {
-  "title": "Barbary Coast",
+  "name": "Barbary Coast",
   "release_year": 1935
 },
 {
-  "title": "Basic Instinct",
+  "name": "Basic Instinct",
   "release_year": 1992
 },
 {
-  "title": "Beaches",
+  "name": "Beaches",
   "release_year": 1988
 },
 {
-  "title": "Bedazzled",
+  "name": "Bedazzled",
   "release_year": 2000
 },
 {
-  "title": "Bee Season",
+  "name": "Bee Season",
   "release_year": 2005
 },
 {
-  "title": "Bicentennial Man",
+  "name": "Bicentennial Man",
   "release_year": 1999
 },
 {
-  "title": "Big Eyes",
+  "name": "Big Eyes",
   "release_year": 2014
 },
 {
-  "title": "Big Sur",
+  "name": "Big Sur",
   "release_year": 2013
 },
 {
-  "title": "Big Touble in Little China",
+  "name": "Big Touble in Little China",
   "release_year": 1986
 },
 {
-  "title": "Birdman of Alcatraz",
+  "name": "Birdman of Alcatraz",
   "release_year": 1962
 },
 {
-  "title": "Blue Jasmine",
+  "name": "Blue Jasmine",
   "release_year": 2013
 },
 {
-  "title": "Boys and Girls",
+  "name": "Boys and Girls",
   "release_year": 2000
 },
 {
-  "title": "Broken-A Modern Love Story",
+  "name": "Broken-A Modern Love Story",
   "release_year": 2010
 },
 {
-  "title": "Bullitt",
+  "name": "Bullitt",
   "release_year": 1968
 },
 {
-  "title": "Burglar",
+  "name": "Burglar",
   "release_year": 1987
 },
 {
-  "title": "By Hook or By Crook",
+  "name": "By Hook or By Crook",
   "release_year": 2001
 },
 {
-  "title": "Can't Stop the Music",
+  "name": "Can't Stop the Music",
   "release_year": 1980
 },
 {
-  "title": "Cardinal X",
+  "name": "Cardinal X",
   "release_year": 2015
 },
 {
-  "title": "Casualties of War",
+  "name": "Casualties of War",
   "release_year": 1989
 },
 {
-  "title": "Chan is Missing",
+  "name": "Chan is Missing",
   "release_year": 1982
 },
 {
-  "title": "Cherish",
+  "name": "Cherish",
   "release_year": 2002
 },
 {
-  "title": "Chu Chu and the Philly Flash",
+  "name": "Chu Chu and the Philly Flash",
   "release_year": 1981
 },
 {
-  "title": "City of Angels",
+  "name": "City of Angels",
   "release_year": 1998
 },
 {
-  "title": "Class Action",
+  "name": "Class Action",
   "release_year": 1991
 },
 {
-  "title": "Common Threads: Stories From the Quilt",
+  "name": "Common Threads: Stories From the Quilt",
   "release_year": 1989
 },
 {
-  "title": "Confessions of a Burning Man",
+  "name": "Confessions of a Burning Man",
   "release_year": 2003
 },
 {
-  "title": "Copycat",
+  "name": "Copycat",
   "release_year": 1995
 },
 {
-  "title": "Crackers",
+  "name": "Crackers",
   "release_year": 1984
 },
 {
-  "title": "CSI: NY- episode 903",
+  "name": "CSI: NY- episode 903",
   "release_year": 2012
 },
 {
-  "title": "D.O.A",
+  "name": "D.O.A",
   "release_year": 1950
 },
 {
-  "title": "Dark Passage",
+  "name": "Dark Passage",
   "release_year": 1947
 },
 {
-  "title": "Dawn of the Planet of the Apes",
+  "name": "Dawn of the Planet of the Apes",
   "release_year": 2014
 },
 {
-  "title": "Days of Wine and Roses",
+  "name": "Days of Wine and Roses",
   "release_year": 1962
 },
 {
-  "title": "Desperate Measures",
+  "name": "Desperate Measures",
   "release_year": 1998
 },
 {
-  "title": "Dim Sum: A Little Bit of Heart",
+  "name": "Dim Sum: A Little Bit of Heart",
   "release_year": 1985
 },
 {
-  "title": "Dirty Harry",
+  "name": "Dirty Harry",
   "release_year": 1971
 },
 {
-  "title": "Doctor Dolittle",
+  "name": "Doctor Dolittle",
   "release_year": 1998
 },
 {
-  "title": "Dopamine",
+  "name": "Dopamine",
   "release_year": 2003
 },
 {
-  "title": "Down Periscope",
+  "name": "Down Periscope",
   "release_year": 1996
 },
 {
-  "title": "Dr. Dolittle 2",
+  "name": "Dr. Dolittle 2",
   "release_year": 2001
 },
 {
-  "title": "Dream for an Insomniac",
+  "name": "Dream for an Insomniac",
   "release_year": 1996
 },
 {
-  "title": "Dream with the Fishes",
+  "name": "Dream with the Fishes",
   "release_year": 1997
 },
 {
-  "title": "Dying Young",
+  "name": "Dying Young",
   "release_year": 1991
 },
 {
-  "title": "Edtv",
+  "name": "Edtv",
   "release_year": 1999
 },
 {
-  "title": "Escape From Alcatraz",
+  "name": "Escape From Alcatraz",
   "release_year": 1979
 },
 {
-  "title": "Experiment in Terror",
+  "name": "Experiment in Terror",
   "release_year": 1962
 },
 {
-  "title": "Faces of Death",
+  "name": "Faces of Death",
   "release_year": 1978
 },
 {
-  "title": "Family Plot",
+  "name": "Family Plot",
   "release_year": 1976
 },
 {
-  "title": "Fandom",
+  "name": "Fandom",
   "release_year": 2004
 },
 {
-  "title": "Fat Man and Little Boy",
+  "name": "Fat Man and Little Boy",
   "release_year": 1989
 },
 {
-  "title": "Fathers' Day",
+  "name": "Fathers' Day",
   "release_year": 1997
 },
 {
-  "title": "Fearless",
+  "name": "Fearless",
   "release_year": 1993
 },
 {
-  "title": "Final Analysis",
+  "name": "Final Analysis",
   "release_year": 1992
 },
 {
-  "title": "Flower Drum Song",
+  "name": "Flower Drum Song",
   "release_year": 1961
 },
 {
-  "title": "Flubber",
+  "name": "Flubber",
   "release_year": 1997
 },
 {
-  "title": "Forrest Gump",
+  "name": "Forrest Gump",
   "release_year": 1994
 },
 {
-  "title": "Foul Play",
+  "name": "Foul Play",
   "release_year": 1978
 },
 {
-  "title": "Freebie and the Bean",
+  "name": "Freebie and the Bean",
   "release_year": 1974
 },
 {
-  "title": "Gentleman Jim",
+  "name": "Gentleman Jim",
   "release_year": 1942
 },
 {
-  "title": "George of the Jungle",
+  "name": "George of the Jungle",
   "release_year": 1997
 },
 {
-  "title": "Getting Even with Dad",
+  "name": "Getting Even with Dad",
   "release_year": 1994
 },
 {
-  "title": "God is a Communist?* (show me heart universe)",
+  "name": "God is a Communist?* (show me heart universe)",
   "release_year": 2010
 },
 {
-  "title": "Godzilla",
+  "name": "Godzilla",
   "release_year": 2014
 },
 {
-  "title": "Golden Gate",
+  "name": "Golden Gate",
   "release_year": 1994
 },
 {
-  "title": "Golden Gate",
+  "name": "Golden Gate",
   "release_year": 1994
 },
 {
-  "title": "Greed",
+  "name": "Greed",
   "release_year": 1924
 },
 {
-  "title": "Groove",
+  "name": "Groove",
   "release_year": 2000
 },
 {
-  "title": "Guess Who's Coming to Dinner",
+  "name": "Guess Who's Coming to Dinner",
   "release_year": 1967
 },
 {
-  "title": "Haiku Tunnel",
+  "name": "Haiku Tunnel",
   "release_year": 2001
 },
 {
-  "title": "Happy Gilmore",
+  "name": "Happy Gilmore",
   "release_year": 1996
 },
 {
-  "title": "Hard to Hold",
+  "name": "Hard to Hold",
   "release_year": 1984
 },
 {
-  "title": "Harold and Maude",
+  "name": "Harold and Maude",
   "release_year": 1971
 },
 {
-  "title": "Heart and Souls",
+  "name": "Heart and Souls",
   "release_year": 1993
 },
 {
-  "title": "Heart Beat",
+  "name": "Heart Beat",
   "release_year": 1980
 },
 {
-  "title": "Hello Frisco, Hello",
+  "name": "Hello Frisco, Hello",
   "release_year": 1943
 },
 {
-  "title": "Hemingway & Gelhorn",
+  "name": "Hemingway & Gelhorn",
   "release_year": 2011
 },
 {
-  "title": "Herbie Rides Again",
+  "name": "Herbie Rides Again",
   "release_year": 1974
 },
 {
-  "title": "Hereafter",
+  "name": "Hereafter",
   "release_year": 2010
 },
 {
-  "title": "High Anxiety",
+  "name": "High Anxiety",
   "release_year": 1977
 },
 {
-  "title": "High Crimes",
+  "name": "High Crimes",
   "release_year": 2002
 },
 {
-  "title": "Homeward Bound II: Lost in San Francisco",
+  "name": "Homeward Bound II: Lost in San Francisco",
   "release_year": 1996
 },
 {
-  "title": "House of Sand and Fog",
+  "name": "House of Sand and Fog",
   "release_year": 2003
 },
 {
-  "title": "How Stella Got Her Groove Back",
+  "name": "How Stella Got Her Groove Back",
   "release_year": 1998
 },
 {
-  "title": "Hulk",
+  "name": "Hulk",
   "release_year": 2003
 },
 {
-  "title": "I Am Michael",
+  "name": "I Am Michael",
   "release_year": 2015
 },
 {
-  "title": "I Remember Mama",
+  "name": "I Remember Mama",
   "release_year": 1948
 },
 {
-  "title": "I's",
+  "name": "I's",
   "release_year": 2011
 },
 {
-  "title": "Indiana Jones and the Last Crusade",
+  "name": "Indiana Jones and the Last Crusade",
   "release_year": 1989
 },
 {
-  "title": "Innerspace",
+  "name": "Innerspace",
   "release_year": 1987
 },
 {
-  "title": "Interview With The Vampire",
+  "name": "Interview With The Vampire",
   "release_year": 1994
 },
 {
-  "title": "Invasion of the Body Snatchers",
+  "name": "Invasion of the Body Snatchers",
   "release_year": 1978
 },
 {
-  "title": "It Came From Beneath the Sea",
+  "name": "It Came From Beneath the Sea",
   "release_year": 1955
 },
 {
-  "title": "Jack",
+  "name": "Jack",
   "release_year": 1996
 },
 {
-  "title": "Jade",
+  "name": "Jade",
   "release_year": 1995
 },
 {
-  "title": "Jagged Edge",
+  "name": "Jagged Edge",
   "release_year": 1985
 },
 {
-  "title": "James and the Giant Peach",
+  "name": "James and the Giant Peach",
   "release_year": 1996
 },
 {
-  "title": "Joy Luck Club",
+  "name": "Joy Luck Club",
   "release_year": 1993
 },
 {
-  "title": "Julie and Jack",
+  "name": "Julie and Jack",
   "release_year": 2003
 },
 {
-  "title": "Junior",
+  "name": "Junior",
   "release_year": 1994
 },
 {
-  "title": "Just Like Heaven",
+  "name": "Just Like Heaven",
   "release_year": 2005
 },
 {
-  "title": "Just One Night",
+  "name": "Just One Night",
   "release_year": 2000
 },
 {
-  "title": "Kamikaze Hearts",
+  "name": "Kamikaze Hearts",
   "release_year": 1986
 },
 {
-  "title": "Knife Fight",
+  "name": "Knife Fight",
   "release_year": 2013
 },
 {
-  "title": "Live Nude Girls Unite",
+  "name": "Live Nude Girls Unite",
   "release_year": 2000
 },
 {
-  "title": "Looking",
+  "name": "Looking",
   "release_year": 2014
 },
 {
-  "title": "Love & Taxes",
+  "name": "Love & Taxes",
   "release_year": 2014
 },
 {
-  "title": "Magnum Force",
+  "name": "Magnum Force",
   "release_year": 1973
 },
 {
-  "title": "Marnie",
+  "name": "Marnie",
   "release_year": 1964
 },
 {
-  "title": "Maxie",
+  "name": "Maxie",
   "release_year": 1985
 },
 {
-  "title": "Memoirs of an Invisible Man",
+  "name": "Memoirs of an Invisible Man",
   "release_year": 1992
 },
 {
-  "title": "Metro",
+  "name": "Metro",
   "release_year": 1997
 },
 {
-  "title": "Midnight Lace",
+  "name": "Midnight Lace",
   "release_year": 1960
 },
 {
-  "title": "Milk",
+  "name": "Milk",
   "release_year": 2008
 },
 {
-  "title": "Mission (aka City of Bars)",
+  "name": "Mission (aka City of Bars)",
   "release_year": 2001
 },
 {
-  "title": "Mona Lisa Smile",
+  "name": "Mona Lisa Smile",
   "release_year": 2003
 },
 {
-  "title": "Mother",
+  "name": "Mother",
   "release_year": 1996
 },
 {
-  "title": "Mrs. Doubtfire",
+  "name": "Mrs. Doubtfire",
   "release_year": 1993
 },
 {
-  "title": "Murder in the First",
+  "name": "Murder in the First",
   "release_year": 2014
 },
 {
-  "title": "Murder in the First",
+  "name": "Murder in the First",
   "release_year": 1995
 },
 {
-  "title": "My Reality",
+  "name": "My Reality",
   "release_year": 2011
 },
 {
-  "title": "Need For Speed",
+  "name": "Need For Speed",
   "release_year": 2014
 },
 {
-  "title": "Never Die Twice",
+  "name": "Never Die Twice",
   "release_year": 2001
 },
 {
-  "title": "Night of Henna",
+  "name": "Night of Henna",
   "release_year": 2005
 },
 {
-  "title": "Nina Takes a Lover",
+  "name": "Nina Takes a Lover",
   "release_year": 1994
 },
 {
-  "title": "Nine Months",
+  "name": "Nine Months",
   "release_year": 1995
 },
 {
-  "title": "Nine to Five",
+  "name": "Nine to Five",
   "release_year": 1980
 },
 {
-  "title": "Nora Prentiss",
+  "name": "Nora Prentiss",
   "release_year": 1947
 },
 {
-  "title": "On the Beach",
+  "name": "On the Beach",
   "release_year": 1959
 },
 {
-  "title": "On the Road",
+  "name": "On the Road",
   "release_year": 2012
 },
 {
-  "title": "Pacific Heights",
+  "name": "Pacific Heights",
   "release_year": 1990
 },
 {
-  "title": "Pal Joey",
+  "name": "Pal Joey",
   "release_year": 1957
 },
 {
-  "title": "Panther",
+  "name": "Panther",
   "release_year": 1995
 },
 {
-  "title": "Parks and Recreation",
+  "name": "Parks and Recreation",
   "release_year": 2014
 },
 {
-  "title": "Patch Adams",
+  "name": "Patch Adams",
   "release_year": 1998
 },
 {
-  "title": "Patty Hearst",
+  "name": "Patty Hearst",
   "release_year": 1988
 },
 {
-  "title": "Petulia",
+  "name": "Petulia",
   "release_year": 1968
 },
 {
-  "title": "Phenomenon",
+  "name": "Phenomenon",
   "release_year": 1996
 },
 {
-  "title": "Play it Again, Sam",
+  "name": "Play it Again, Sam",
   "release_year": 1972
 },
 {
-  "title": "Playing Mona Lisa",
+  "name": "Playing Mona Lisa",
   "release_year": 2000
 },
 {
-  "title": "Pleasure of His Company",
+  "name": "Pleasure of His Company",
   "release_year": 1961
 },
 {
-  "title": "Point Blank",
+  "name": "Point Blank",
   "release_year": 1967
 },
 {
-  "title": "Pretty Woman",
+  "name": "Pretty Woman",
   "release_year": 1990
 },
 {
-  "title": "Psych-Out",
+  "name": "Psych-Out",
   "release_year": 1968
 },
 {
-  "title": "Quicksilver",
+  "name": "Quicksilver",
   "release_year": 1986
 },
 {
-  "title": "Quitters",
+  "name": "Quitters",
   "release_year": 2015
 },
 {
-  "title": "Raising Cain",
+  "name": "Raising Cain",
   "release_year": 1992
 },
 {
-  "title": "Red Diaper Baby",
+  "name": "Red Diaper Baby",
   "release_year": 2004
 },
 {
-  "title": "Red Widow",
+  "name": "Red Widow",
   "release_year": 2013
 },
 {
-  "title": "Rent",
+  "name": "Rent",
   "release_year": 2005
 },
 {
-  "title": "Rollerball",
+  "name": "Rollerball",
   "release_year": 2002
 },
 {
-  "title": "Romeo Must Die",
+  "name": "Romeo Must Die",
   "release_year": 2000
 },
 {
-  "title": "San Andreas",
+  "name": "San Andreas",
   "release_year": 2015
 },
 {
-  "title": "San Francisco",
+  "name": "San Francisco",
   "release_year": 1936
 },
 {
-  "title": "Sausalito",
+  "name": "Sausalito",
   "release_year": 2000
 },
 {
-  "title": "Sense8",
+  "name": "Sense8",
   "release_year": 2015
 },
 {
-  "title": "Serendipity",
+  "name": "Serendipity",
   "release_year": 2001
 },
 {
-  "title": "Serial",
+  "name": "Serial",
   "release_year": 1980
 },
 {
-  "title": "Seven Girlfriends",
+  "name": "Seven Girlfriends",
   "release_year": 1999
 },
 {
-  "title": "Shadow of the Thin Man",
+  "name": "Shadow of the Thin Man",
   "release_year": 1941
 },
 {
-  "title": "Shattered",
+  "name": "Shattered",
   "release_year": 1991
 },
 {
-  "title": "Shoot the Moon",
+  "name": "Shoot the Moon",
   "release_year": 1982
 },
 {
-  "title": "Sister Act",
+  "name": "Sister Act",
   "release_year": 1992
 },
 {
-  "title": "Sister Act 2: Back in the Habit",
+  "name": "Sister Act 2: Back in the Habit",
   "release_year": 1993
 },
 {
-  "title": "Smile Again, Jenny Lee",
+  "name": "Smile Again, Jenny Lee",
   "release_year": 2015
 },
 {
-  "title": "Sneakers",
+  "name": "Sneakers",
   "release_year": 1992
 },
 {
-  "title": "So I Married an Axe Murderer",
+  "name": "So I Married an Axe Murderer",
   "release_year": 1993
 },
 {
-  "title": "Sphere",
+  "name": "Sphere",
   "release_year": 1998
 },
 {
-  "title": "Star Trek II : The Wrath of Khan",
+  "name": "Star Trek II : The Wrath of Khan",
   "release_year": 1982
 },
 {
-  "title": "Star Trek IV: The Voyage Home",
+  "name": "Star Trek IV: The Voyage Home",
   "release_year": 1986
 },
 {
-  "title": "Star Trek VI: The Undiscovered Country",
+  "name": "Star Trek VI: The Undiscovered Country",
   "release_year": 1991
 },
 {
-  "title": "Steve Jobs",
+  "name": "Steve Jobs",
   "release_year": 2015
 },
 {
-  "title": "Stigmata",
+  "name": "Stigmata",
   "release_year": 1999
 },
 {
-  "title": "Street Music",
+  "name": "Street Music",
   "release_year": 1981
 },
 {
-  "title": "Sudden Fear",
+  "name": "Sudden Fear",
   "release_year": 1952
 },
 {
-  "title": "Sudden Impact",
+  "name": "Sudden Impact",
   "release_year": 1983
 },
 {
-  "title": "Summertime",
+  "name": "Summertime",
   "release_year": 2015
 },
 {
-  "title": "Superman",
+  "name": "Superman",
   "release_year": 1978
 },
 {
-  "title": "Susan Slade",
+  "name": "Susan Slade",
   "release_year": 1961
 },
 {
-  "title": "Sweet November",
+  "name": "Sweet November",
   "release_year": 2001
 },
 {
-  "title": "Swing",
+  "name": "Swing",
   "release_year": 2003
 },
 {
-  "title": "Swingin' Along",
+  "name": "Swingin' Along",
   "release_year": 1961
 },
 {
-  "title": "Take the Money and Run",
+  "name": "Take the Money and Run",
   "release_year": 1969
 },
 {
-  "title": "Terminator - Genisys",
+  "name": "Terminator - Genisys",
   "release_year": 2015
 },
 {
-  "title": "The Assassination of Richard Nixon",
+  "name": "The Assassination of Richard Nixon",
   "release_year": 2004
 },
 {
-  "title": "The Bachelor",
+  "name": "The Bachelor",
   "release_year": 1999
 },
 {
-  "title": "The Birds",
+  "name": "The Birds",
   "release_year": 1963
 },
 {
-  "title": "The Bridge",
+  "name": "The Bridge",
   "release_year": 2006
 },
 {
-  "title": "The Caine Mutiny",
+  "name": "The Caine Mutiny",
   "release_year": 1954
 },
 {
-  "title": "The Californians",
+  "name": "The Californians",
   "release_year": 2005
 },
 {
-  "title": "The Candidate",
+  "name": "The Candidate",
   "release_year": 1972
 },
 {
-  "title": "The Competition",
+  "name": "The Competition",
   "release_year": 1980
 },
 {
-  "title": "The Conversation",
+  "name": "The Conversation",
   "release_year": 1974
 },
 {
-  "title": "The Core",
+  "name": "The Core",
   "release_year": 2003
 },
 {
-  "title": "The Dead Pool",
+  "name": "The Dead Pool",
   "release_year": 1988
 },
 {
-  "title": "The Diary of a Teenage Girl",
+  "name": "The Diary of a Teenage Girl",
   "release_year": 2015
 },
 {
-  "title": "The Doctor",
+  "name": "The Doctor",
   "release_year": 1991
 },
 {
-  "title": "The Doors",
+  "name": "The Doors",
   "release_year": 1991
 },
 {
-  "title": "The Enforcer",
+  "name": "The Enforcer",
   "release_year": 1976
 },
 {
-  "title": "The Fan",
+  "name": "The Fan",
   "release_year": 1996
 },
 {
-  "title": "The Fog of War",
+  "name": "The Fog of War",
   "release_year": 2003
 },
 {
-  "title": "The Game",
+  "name": "The Game",
   "release_year": 1997
 },
 {
-  "title": "The Graduate",
+  "name": "The Graduate",
   "release_year": 1967
 },
 {
-  "title": "The House on Telegraph Hill",
+  "name": "The House on Telegraph Hill",
   "release_year": 1951
 },
 {
-  "title": "The Internship",
+  "name": "The Internship",
   "release_year": 2013
 },
 {
-  "title": "The Jazz Singer",
+  "name": "The Jazz Singer",
   "release_year": 1927
 },
 {
-  "title": "The Lady from Shanghai",
+  "name": "The Lady from Shanghai",
   "release_year": 1947
 },
 {
-  "title": "The Last of the Gladiators",
+  "name": "The Last of the Gladiators",
   "release_year": 1988
 },
 {
-  "title": "The Laughing Policeman",
+  "name": "The Laughing Policeman",
   "release_year": 1973
 },
 {
-  "title": "The Lineup",
+  "name": "The Lineup",
   "release_year": 1958
 },
 {
-  "title": "The Love Bug",
+  "name": "The Love Bug",
   "release_year": 1968
 },
 {
-  "title": "The Maltese Falcon",
+  "name": "The Maltese Falcon",
   "release_year": 1941
 },
 {
-  "title": "The Master",
+  "name": "The Master",
   "release_year": 2012
 },
 {
-  "title": "The Matrix",
+  "name": "The Matrix",
   "release_year": 1999
 },
 {
-  "title": "The Net",
+  "name": "The Net",
   "release_year": 1995
 },
 {
-  "title": "The Nightmare Before Christmas",
+  "name": "The Nightmare Before Christmas",
   "release_year": 1993
 },
 {
-  "title": "The Organization",
+  "name": "The Organization",
   "release_year": 1971
 },
 {
-  "title": "The Other Sister",
+  "name": "The Other Sister",
   "release_year": 1999
 },
 {
-  "title": "The Parent Trap",
+  "name": "The Parent Trap",
   "release_year": 1998
 },
 {
-  "title": "The Presidio",
+  "name": "The Presidio",
   "release_year": 1988
 },
 {
-  "title": "The Princess Diaries",
+  "name": "The Princess Diaries",
   "release_year": 2001
 },
 {
-  "title": "The Pursuit of Happyness",
+  "name": "The Pursuit of Happyness",
   "release_year": 2006
 },
 {
-  "title": "The Right Stuff",
+  "name": "The Right Stuff",
   "release_year": 1983
 },
 {
-  "title": "The Rock",
+  "name": "The Rock",
   "release_year": 1996
 },
 {
-  "title": "The Sweetest Thing",
+  "name": "The Sweetest Thing",
   "release_year": 2002
 },
 {
-  "title": "The Ten Commandments",
+  "name": "The Ten Commandments",
   "release_year": 1923
 },
 {
-  "title": "The Times of Harvey Milk",
+  "name": "The Times of Harvey Milk",
   "release_year": 1984
 },
 {
-  "title": "The Towering Inferno",
+  "name": "The Towering Inferno",
   "release_year": 1974
 },
 {
-  "title": "The Wedding Planner",
+  "name": "The Wedding Planner",
   "release_year": 2001
 },
 {
-  "title": "The Woman In Red",
+  "name": "The Woman In Red",
   "release_year": 1984
 },
 {
-  "title": "The Zodiac",
+  "name": "The Zodiac",
   "release_year": 2005
 },
 {
-  "title": "They Call Me MISTER Tibbs",
+  "name": "They Call Me MISTER Tibbs",
   "release_year": 1970
 },
 {
-  "title": "Thief of Hearts",
+  "name": "Thief of Hearts",
   "release_year": 1984
 },
 {
-  "title": "Time After Time",
+  "name": "Time After Time",
   "release_year": 1979
 },
 {
-  "title": "Tin Cup",
+  "name": "Tin Cup",
   "release_year": 1996
 },
 {
-  "title": "To the Ends of the Earth",
+  "name": "To the Ends of the Earth",
   "release_year": 1948
 },
 {
-  "title": "True Believer",
+  "name": "True Believer",
   "release_year": 1989
 },
 {
-  "title": "Tucker: The Man and His Dream",
+  "name": "Tucker: The Man and His Dream",
   "release_year": 1988
 },
 {
-  "title": "Tweek City",
+  "name": "Tweek City",
   "release_year": 2005
 },
 {
-  "title": "Twisted",
+  "name": "Twisted",
   "release_year": 2004
 },
 {
-  "title": "Under the Tuscan Sun",
+  "name": "Under the Tuscan Sun",
   "release_year": 2003
 },
 {
-  "title": "Until the End of the World",
+  "name": "Until the End of the World",
   "release_year": 1991
 },
 {
-  "title": "Vegas in Space",
+  "name": "Vegas in Space",
   "release_year": 1992
 },
 {
-  "title": "Vertigo",
+  "name": "Vertigo",
   "release_year": 1958
 },
 {
-  "title": "What Dreams May Come",
+  "name": "What Dreams May Come",
   "release_year": 1998
 },
 {
-  "title": "What the Bleep Do We Know",
+  "name": "What the Bleep Do We Know",
   "release_year": 2004
 },
 {
-  "title": "What's Up Doc?",
+  "name": "What's Up Doc?",
   "release_year": 1972
 },
 {
-  "title": "When a Man Loves a Woman",
+  "name": "When a Man Loves a Woman",
   "release_year": 1994
 },
 {
-  "title": "Woman on the Run",
+  "name": "Woman on the Run",
   "release_year": 1950
 },
 {
-  "title": "Woman on Top",
+  "name": "Woman on Top",
   "release_year": 2000
 },
 {
-  "title": "Yours, Mine and Ours",
+  "name": "Yours, Mine and Ours",
   "release_year": 1968
 },
 {
-  "title": "Zodiac",
+  "name": "Zodiac",
   "release_year": 2007
 }]

--- a/db/seeds/index.js
+++ b/db/seeds/index.js
@@ -1,10 +1,19 @@
 'use strict';
 
-const Movies = require('./data/movies');
+const Bluebird = require('bluebird');
+
+const Locations = require('./data/locations');
+const Movies    = require('./data/movies');
 
 exports.seed = function (Knex) {
-  return Knex('movies').truncate()
+  return Bluebird.all([
+    Knex('movies').truncate(),
+    Knex('locations').truncate()
+  ])
   .then(() => {
-    return Knex('movies').insert(Movies);
+    return Bluebird.all([
+      Knex('movies').insert(Movies),
+      Knex('locations').insert(Locations)
+    ]);
   });
 };

--- a/lib/models/location.js
+++ b/lib/models/location.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+
+module.exports = Bookshelf.Model.extend({
+  tableName: 'locations',
+
+  serialize: function () {
+    return {
+      id: this.get('id'),
+      city: this.get('city'),
+      state: this.get('state'),
+      object: 'location'
+    };
+  }
+});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -109,7 +109,7 @@
     },
     "bluebird": {
       "version": "3.4.6",
-      "from": "bluebird@>=3.0.6 <4.0.0",
+      "from": "bluebird@*",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
     },
     "bookshelf": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nodemon": "^1.10.2"
   },
   "dependencies": {
+    "bluebird": "^3.4.6",
     "bookshelf": "^0.10.2",
     "hapi": "^15.1.1",
     "hapi-bookshelf-serializer": "^2.1.0",

--- a/test/models/location.test.js
+++ b/test/models/location.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Location = require('../../lib/models/location');
+
+describe('location model', () => {
+
+  describe('serialize', () => {
+
+    it('includes all of the necessary fields', () => {
+      const location = Location.forge().serialize();
+
+      expect(location).to.have.all.keys([
+        'id',
+        'city',
+        'state',
+        'object'
+      ]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
**What:**
Introduces a locations model and table with `city` and `state` attributes.

**Why:**
This work leads up to [ENG-1253](https://lobsters.atlassian.net/browse/ENG-1253), which requires movies to be associated with multiple locations.

**Details:**
- Introduces a migration file to create the `locations` table.
- Introduces location model with `serialize` method.
- Introduces a seed file for the locations table.
- I did not associate movies with locations yet because I plan on creating an association table in a future PR.
- Minor bugfix included in CR (see movies.json). `title` should be renamed to `name` since the column was renamed through a series of previous PRs.
