### PR TITLE
feat(byoapi): Associate movies with multiple locations

### DIFF
--- a/db/migrations/20161007170112_create_locations_movies.js
+++ b/db/migrations/20161007170112_create_locations_movies.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.schema.createTable('locations_movies', (table) => {
+    table.increments('id').primary();
+    table.integer('movie_id');
+    table.integer('location_id');
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.dropTable('locations_movies');
+};

--- a/lib/models/locations_movies.js
+++ b/lib/models/locations_movies.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+
+module.exports = Bookshelf.Model.extend({
+  tableName: 'locations_movies'
+});

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -1,9 +1,23 @@
 'use strict';
 
 const Bookshelf = require('../libraries/bookshelf');
+const Knex      = require('../libraries/knex');
+const Location  = require('./location');
 
 module.exports = Bookshelf.Model.extend({
   tableName: 'movies',
+
+  locations: function () {
+    return Knex('locations_movies')
+    .where('movie_id', this.get('id'))
+    .then((result) => {
+      const locationIds = result.map((r) => r.location_id);
+      return new Location().query((qb) => {
+        qb.whereIn('id', locationIds);
+      })
+      .fetchAll();
+    });
+  },
 
   filterByYear: function (releaseYear, releaseYearStart, releaseYearEnd) {
     return this.query((qb) => {
@@ -28,11 +42,16 @@ module.exports = Bookshelf.Model.extend({
   },
 
   serialize: function () {
-    return {
-      id: this.get('id'),
-      title: this.get('name'),
-      release_year: this.get('release_year'),
-      object: 'movie'
-    };
+    return this.locations()
+    .then((locations) => {
+      const serializedLocations = locations.map((location) => location.serialize());
+      return {
+        id: this.get('id'),
+        title: this.get('name'),
+        release_year: this.get('release_year'),
+        locations: serializedLocations,
+        object: 'movie'
+      };
+    });
   }
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "test:raw": "NODE_ENV=test mocha test --require test/setup.js --recursive --timeout 30000",
+    "test:debug": "npm run test:raw -- debug",
     "start": "nodemon --ignore test/",
     "db:migrate": "knex migrate:latest --knexfile db/index.js",
     "db:migrate:make": "knex migrate:make --knexfile db/index.js",


### PR DESCRIPTION
**What:**
Associate movies with multiple locations.

**Why:**
For ENG-1252 as part of the engineering onboarding process.

**Describe:**
- Adds migration to create `locations_movies` association table
  - Did not create foreign keys because Bookshelf was not cooperating
- Created lightweight model for association table, for easy CRUD operations
- Add `locations` method on Movie that returns a Bookshelf collection of Location objects associated with the movie
- Changed `serialize`to include associated locations
